### PR TITLE
Open a port when the topics and subscriptions have been created

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ export PUBSUB_EMULATOR_HOST=localhost:8681
 ./myapp
 ```
 
+### Automatic topic and subscription creation
 This image also provides the ability to create topics and subscriptions in projects on startup by specifying the `PUBSUB_PROJECT` environment variable with a sequentual number appended to it, starting with _1_. The format of the environment variable is simple:
 
 ```
-PROJECTID,TOPIC:SUBSCRIPTION
+PROJECTID,TOPIC1,TOPIC2:SUBSCRIPTION1,SUBSCRIPTION2,TOPIC3:SUBSCRIPTION3
 ```
 
 A comma-separated list where the first item is the _project ID_ and the rest are topics. The topics themselves are colon-separated where the first item is the _topic ID_ and the rest are _subscription IDs_. A topic doesn't necessarily need to specify subscriptions.
@@ -53,3 +54,6 @@ docker run --rm -ti -p 8681:8681 -e PUBSUB_PROJECT1=company-dev,invoices:invoice
 ```
 
 If you want to define more projects, you'd simply add a `PUBSUB_PROJECT2`, `PUBSUB_PROJECT3`, etc.
+
+### wait-for, wait-for-it
+If you're using this Docker image in a docker-compose setup or something similar, you might have leveraged scripts like [wait-for](https://github.com/eficode/wait-for) or [wait-for-it](https://github.com/vishnubob/wait-for-it) to detect when the PubSub service comes up before starting a container that depends on it being up. If you're _not_ using the above-mentioned _PUBSUB_PROJECT_ environment variable, you can simply check if port `8681` is available. If you _do_ depend on one or more _PUBSUB_PROJECT_ environment variables, you should check for the availability of port `8682` as that one will become available once all the topics and subscriptions have been created.

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,10 @@
 
 # Start the PubSub client in the background. It will poll for an open PubSub
 # emulator port and create its topics and subscriptions when it's up.
-/usr/bin/wait-for localhost:8681 -- env PUBSUB_EMULATOR_HOST=localhost:8681 /usr/bin/pubsubc -debug &
+#
+# After it's done, port 8682 will be open to facilitate the wait-for and
+# wait-for-it scripts.
+(/usr/bin/wait-for localhost:8681 -- env PUBSUB_EMULATOR_HOST=localhost:8681 /usr/bin/pubsubc -debug; nc -lkp 8682 >/dev/null) &
 
 # Start the PubSub emulator in the foreground.
 gcloud beta emulators pubsub start --host-port=0.0.0.0:8681


### PR DESCRIPTION
This PR opens a TCP port when the `pubsubc` command has ran, so it can be polled for by `wait-for`-like scripts.