### PR TITLE
Use OpenBSD's netcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY --from=builder /usr/bin/wait-for /usr/bin
 COPY --from=builder /go/bin/pubsubc   /usr/bin
 COPY                run.sh            /run.sh
 
-RUN apk --update add openjdk7-jre && gcloud components install beta pubsub-emulator
+RUN apk --update add openjdk7-jre netcat-openbsd && gcloud components install beta pubsub-emulator
 
 EXPOSE 8681
 


### PR DESCRIPTION
Busybox's netcat doesn't accept multiple connections, only the one, it seems. Use OpenBSD's netcat instead, which works as advertised.