### PR TITLE
Accept and pass emulator options in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,4 +8,4 @@
 (/usr/bin/wait-for localhost:8681 -- env PUBSUB_EMULATOR_HOST=localhost:8681 /usr/bin/pubsubc -debug; nc -lkp 8682 >/dev/null) &
 
 # Start the PubSub emulator in the foreground.
-gcloud beta emulators pubsub start --host-port=0.0.0.0:8681
+gcloud beta emulators pubsub start --host-port=0.0.0.0:8681 "$@"


### PR DESCRIPTION
We need to pass debug options like `--log-http --verbosity=debug --user-output-enabled`.