### PR TITLE
Configure startup timeout

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@
 #
 # After it's done, port 8682 will be open to facilitate the wait-for and
 # wait-for-it scripts.
-(/usr/bin/wait-for localhost:8681 -- env PUBSUB_EMULATOR_HOST=localhost:8681 /usr/bin/pubsubc -debug; nc -lkp 8682 >/dev/null) &
+(/usr/bin/wait-for localhost:8681 -t "${TIMEOUT:-15}" -- env PUBSUB_EMULATOR_HOST=localhost:8681 /usr/bin/pubsubc -debug; nc -lkp 8682 >/dev/null) &
 
 # Start the PubSub emulator in the foreground.
 gcloud beta emulators pubsub start --host-port=0.0.0.0:8681 "$@"


### PR DESCRIPTION
This change configures a timeout for the `wait-for` startup command. The default value of 15 seconds is the same that exists in `wait-for`.