### PR TITLE
Remove timeout for `wait-for` command

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@
 #
 # After it's done, port 8682 will be open to facilitate the wait-for and
 # wait-for-it scripts.
-(/usr/bin/wait-for localhost:8681 -- env PUBSUB_EMULATOR_HOST=localhost:8681 /usr/bin/pubsubc -debug; nc -lkp 8682 >/dev/null) &
+(/usr/bin/wait-for localhost:8681 --timeout=0 -- env PUBSUB_EMULATOR_HOST=localhost:8681 /usr/bin/pubsubc -debug; nc -lkp 8682 >/dev/null) &
 
 # Start the PubSub emulator in the foreground.
 gcloud beta emulators pubsub start --host-port=0.0.0.0:8681 "$@"


### PR DESCRIPTION
The default timeout for `wait-for` is 15 seconds.  If service startup happens to take a long time then the subscription setup portion fails but it doesn't shutdown the container or anything.  

I think just setting the timeout to infinite is probably a good enough solution since it's likely that the emulator will startup eventually.  A better solution could be to kill the emulator if it doesn't startup in time, but in that case I think you'd want the timeout to be configurable just in case someone has a REALLY slow startup.